### PR TITLE
patches: search commit on correct branch for ClusterLabs' repos

### DIFF
--- a/patches/0009-use-main-branch-clusterlab.patch
+++ b/patches/0009-use-main-branch-clusterlab.patch
@@ -1,0 +1,30 @@
+ meta-cgl-common/recipes-cgl/cluster-resource-agents/resource-agents_4.5.0.bb | 2 +-
+ meta-cgl-common/recipes-cgl/pacemaker/pacemaker_2.0.3.bb                     | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/sources/meta-cgl/meta-cgl-common/recipes-cgl/cluster-resource-agents/resource-agents_4.5.0.bb b/sources/meta-cgl/meta-cgl-common/recipes-cgl/cluster-resource-agents/resource-agents_4.5.0.bb
+index d34d706..28cfc6a 100644
+--- a/sources/meta-cgl/meta-cgl-common/recipes-cgl/cluster-resource-agents/resource-agents_4.5.0.bb
++++ b/sources/meta-cgl/meta-cgl-common/recipes-cgl/cluster-resource-agents/resource-agents_4.5.0.bb
+@@ -14,7 +14,7 @@ LICENSE_${PN}-extra = "GPLv3"
+ LICENSE_${PN}-extra-dbg = "GPLv3"
+ LICENSE_ldirectord = "GPLv2+"
+ 
+-SRC_URI = "git://github.com/ClusterLabs/resource-agents \
++SRC_URI = "git://github.com/ClusterLabs/resource-agents;branch=main \
+            file://01-disable-doc-build.patch \
+            file://02-set-OCF_ROOT_DIR-to-libdir-ocf.patch \
+            file://03-fix-header-defs-lookup.patch \
+diff --git a/sources/meta-cgl/meta-cgl-common/recipes-cgl/pacemaker/pacemaker_2.0.3.bb b/sources/meta-cgl/meta-cgl-common/recipes-cgl/pacemaker/pacemaker_2.0.3.bb
+index 9b63acd..2adff5a 100644
+--- a/sources/meta-cgl/meta-cgl-common/recipes-cgl/pacemaker/pacemaker_2.0.3.bb
++++ b/sources/meta-cgl/meta-cgl-common/recipes-cgl/pacemaker/pacemaker_2.0.3.bb
+@@ -13,7 +13,7 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=000212f361a81b100d9d0f0435040663"
+ 
+ DEPENDS = "corosync libxslt libxml2 gnutls resource-agents libqb python3-native"
+ 
+-SRC_URI = "git://github.com/ClusterLabs/${BPN}.git \
++SRC_URI = "git://github.com/ClusterLabs/${BPN}.git;branch=main \
+            file://0006-Fix-tools-Fix-definition-of-curses_indented_printf.patch \
+            file://0001-Fix-python3-usage.patch \
+            file://volatiles \


### PR DESCRIPTION
resources-agents and pacemaker do not have any "master" branch
anymore and now use a "main" branch, causing the build to fails
to fetch SRCREV.

Signed-off-by: Sébastien Blin <sebastien.blin@savoirfairelinux.com>

----

Original error:

```

NOTE: Fetching uninative binary shim http://downloads.yoctoproject.org/releases/uninative/3.4/x86_64-nativesdk-libc.tar.xz;sha256sum=126f4f7f6f21084ee140dac3eb4c536b963837826b7c38599db0b512c3377ba2 (will check PREMIRRORS first)
NOTE: [Hardening]: started
Initialising tasks: 100% |###################################################################################################| Time: 0:00:04
Sstate summary: Wanted 2545 Found 0 Missed 2545 Current 0 (0% match, 0% complete)
NOTE: Executing Tasks
WARNING: Duplicate inclusion for /home/sfl/seapath/sources/poky/meta/conf/distro/include/security_flags.inc in /home/sfl/seapath/build/conf/bblayers.conf
WARNING: Duplicate inclusion for /home/sfl/seapath/sources/meta-virtualization/conf/distro/include/virt_security_flags.inc in /home/sfl/seapath/build/conf/bblayers.conf
WARNING: Duplicate inclusion for /home/sfl/seapath/sources/meta-cgl/meta-cgl-common/conf/distro/include/cgl_common_security_flags.inc in /home/sfl/seapath/build/conf/bblayers.conf
WARNING: libpcre2-native-10.34-r0 do_fetch: Failed to fetch URL https://github.com/PhilipHazel/pcre2/releases/download/pcre2-10.34/pcre2-10.34.tar.bz2, attempting MIRRORS if available
WARNING: linux-firmware-1_20211027-r0 do_fetch: Failed to fetch URL https://cdn.kernel.org/pub/linux/kernel/firmware/linux-firmware-20211027.tar.xz, attempting MIRRORS if available
WARNING: resource-agents-4.5.0-r0 do_fetch: Failed to fetch URL git://github.com/ClusterLabs/resource-agents, attempting MIRRORS if available
ERROR: resource-agents-4.5.0-r0 do_fetch: Fetcher failure: Unable to find revision fee181320547365d7f8c88cca2b32801412b933d in branch master even from upstream
ERROR: resource-agents-4.5.0-r0 do_fetch: Bitbake Fetcher Error: FetchError('Unable to fetch URL from any source.', 'git://github.com/ClusterLabs/resource-agents')
ERROR: Logfile of failure stored in: /home/sfl/seapath/build/tmp/work/corei7-64-poky-linux/resource-agents/4.5.0-r0/temp/log.do_fetch.641870
ERROR: Task (/home/sfl/seapath/sources/meta-cgl/meta-cgl-common/recipes-cgl/cluster-resource-agents/resource-agents_4.5.0.bb:do_fetch) failed with exit code '1'
NOTE: Tasks Summary: Attempted 1619 tasks of which 0 didn't need to be rerun and 1 failed.
NOTE: Writing buildhistory
NOTE: Writing buildhistory took: 2 seconds
NOTE: [Hardening]: done
WARNING: Path /home/sfl/seapath/build/security/manifests/20211227185959 does not exist. Archiving is skipped

Summary: 1 task failed:
  /home/sfl/seapath/sources/meta-cgl/meta-cgl-common/recipes-cgl/cluster-resource-agents/resource-agents_4.5.0.bb:do_fetch
Summary: There were 16 WARNING messages shown.
Summary: There were 2 ERROR messages shown, returning a non-zero exit code.

```