### PR TITLE
Refactoring Yocto DISTRO and IMAGES

### DIFF
--- a/.cqfdrc
+++ b/.cqfdrc
@@ -19,6 +19,7 @@ flavors='
     guest_efi_dbg
     host_bios
     host_bios_dbg
+    host_bios_minimal
     host_bios_no_iommu
     host_bios_test
     host_bios_test_no_iommu
@@ -37,29 +38,29 @@ command=' \
     ./build.sh -v -i seapath-flash-bios --distro seapath-flash && \
     ./build.sh -v -i seapath-flash-efi --distro seapath-flash && \
     ./build.sh -v -i seapath-flash-pxe --distro seapath-flash && \
-    ./build.sh -v -i seapath-guest-efi-image --machine votp-vm && \
-    ./build.sh -v -i seapath-guest-efi-test-image --machine votp-vm && \
-    ./build.sh -v -i seapath-guest-efi-dbg-image --machine votp-vm && \
-    ./build.sh -v -i seapath-host-bios-image --distro seapath-ro && \
-    ./build.sh -v -i seapath-host-bios-dbg-image && \
+    ./build.sh -v -i seapath-guest-efi-image --distro seapath-guest --machine votp-vm && \
+    ./build.sh -v -i seapath-guest-efi-test-image --distro seapath-guest --machine votp-vm && \
+    ./build.sh -v -i seapath-guest-efi-dbg-image --distro seapath-guest --machine votp-vm && \
+    ./build.sh -v -i seapath-host-bios-image --distro seapath-host && \
+    ./build.sh -v -i seapath-host-bios-dbg-image --distro seapath-host && \
     ./build.sh -v \
         -i seapath-host-bios-no-iommu-image \
         --machine votp-no-iommu \
-        --distro seapath-ro && \
-    ./build.sh -v -i seapath-host-bios-test-image && \
+        --distro seapath-host && \
+    ./build.sh -v -i seapath-host-bios-test-image --distro seapath-host && \
     ./build.sh -v -i seapath-host-bios-test-no-iommu-image \
-        --machine votp-no-iommu && \
-    ./build.sh -v -i seapath-host-efi-dbg-image && \
-    ./build.sh -v -i seapath-host-efi-test-image && \
-    ./build.sh -v -i seapath-host-efi-swu-image --distro seapath-ro && \
+        --machine votp-no-iommu --distro seapath-host && \
+    ./build.sh -v -i seapath-host-efi-dbg-image --distro seapath-host && \
+    ./build.sh -v -i seapath-host-efi-test-image --distro seapath-host && \
+    ./build.sh -v -i seapath-host-efi-swu-image --distro seapath-host && \
     ./build.sh -v \
         -i seapath-monitor-bios-image \
         --machine votp-monitor \
-        --distro seapath-ro && \
+        --distro seapath-host && \
     ./build.sh -v \
         -i seapath-monitor-efi-swu-image \
         --machine votp-monitor \
-        --distro seapath-ro && \
+        --distro seapath-host && \
     ./tools/get-pkg-list-csv.sh ./build/security/manifests/*.manifest > \
         ./build/security/manifests/pkg-list_$(date -u +"%Y-%m-%d_%H:%M:%S").csv \
 '
@@ -74,93 +75,96 @@ command='./build.sh -v -i seapath-flash-efi --distro seapath-flash'
 command='./build.sh -v -i seapath-flash-pxe --distro seapath-flash'
 
 [guest_efi]
-command='./build.sh -v -i seapath-guest-efi-image --machine votp-vm'
+command='./build.sh -v -i seapath-guest-efi-image --distro seapath-guest --machine votp-vm'
 
 [guest_efi_dbg]
-command='./build.sh -v -i seapath-guest-efi-dbg-image --machine votp-vm'
+command='./build.sh -v -i seapath-guest-efi-dbg-image --distro seapath-guest --machine votp-vm'
 
 [guest_efi_test]
-command='./build.sh -v -i seapath-guest-efi-test-image --machine votp-vm'
+command='./build.sh -v -i seapath-guest-efi-test-image --distro seapath-guest --machine votp-vm'
 
 [host_bios]
-command='./build.sh -v -i seapath-host-bios-image --distro seapath-ro'
+command='./build.sh -v -i seapath-host-bios-image --distro seapath-host'
+
+[host_bios_minimal]
+command='./build.sh -v -i seapath-host-bios-image --distro seapath-host-minimal'
 
 [host_bios_no_iommu]
 command='./build.sh -v \
     -i seapath-host-bios-no-iommu-image \
     --machine votp-no-iommu \
-    --distro seapath-ro'
+    --distro seapath-host'
 
 [host_bios_dbg]
-command='./build.sh -v -i seapath-host-bios-dbg-image --distro seapath-ro'
+command='./build.sh -v -i seapath-host-bios-dbg-image --distro seapath-host'
 
 [host_bios_test]
-command='./build.sh -v -i seapath-host-bios-test-image'
+command='./build.sh -v -i seapath-host-bios-test-image --distro seapath-host'
 
 [host_bios_test_no_iommu]
 command='./build.sh -v -i seapath-host-bios-test-no-iommu-image \
-        --machine votp-no-iommu'
+        --machine votp-no-iommu --distro seapath-host'
 
 [host_efi]
-command='./build.sh -v -i seapath-host-efi-image --distro seapath-ro'
+command='./build.sh -v -i seapath-host-efi-image --distro seapath-host'
 
 [host_efi_dbg]
-command='./build.sh -v -i seapath-host-efi-dbg-image'
+command='./build.sh -v -i seapath-host-efi-dbg-image --distro seapath-host'
 
 [host_efi_test]
-command='./build.sh -v -i seapath-host-efi-test-image'
+command='./build.sh -v -i seapath-host-efi-test-image --distro seapath-host'
 
 [host_efi_swu]
-command='./build.sh -v -i seapath-host-efi-swu-image --distro seapath-ro'
+command='./build.sh -v -i seapath-host-efi-swu-image --distro seapath-host'
 
 [monitor_bios]
 command='./build.sh -v \
     -i seapath-monitor-bios-image \
     --machine votp-monitor \
-    --distro seapath-ro \
+    --distro seapath-host \
 '
 
 [monitor_efi]
 command='./build.sh -v \
     -i seapath-monitor-efi-image \
     --machine votp-monitor \
-    --distro seapath-ro \
+    --distro seapath-host \
 '
 
 [monitor_efi_swu]
 command='./build.sh -v \
     -i seapath-monitor-efi-swu-image \
     --machine votp-monitor \
-    --distro seapath-ro \
+    --distro seapath-host \
 '
 
 [sfl_ci]
 command=' \
-    ./build.sh -v -i seapath-host-efi-image --distro seapath-ro \
+    ./build.sh -v -i seapath-host-efi-image --distro seapath-host \
         --dl-dir /mnt/dldir \
         --sstate-dir /mnt/sstate && \
-    ./build.sh -v -i seapath-host-efi-dbg-image \
+    ./build.sh -v -i seapath-host-efi-dbg-image --distro seapath-host \
         --dl-dir /mnt/dldir \
         --sstate-dir /mnt/sstate && \
     ./build.sh -v -i seapath-flash-pxe \
         --distro seapath-flash \
         --dl-dir /mnt/dldir \
         --sstate-dir /mnt/sstate && \
-    ./build.sh -v -i seapath-guest-efi-image \
+    ./build.sh -v -i seapath-guest-efi-image --distro seapath-guest \
         --machine votp-vm \
         --dl-dir /mnt/dldir \
         --sstate-dir /mnt/sstate && \
-    ./build.sh -v -i seapath-guest-efi-test-image \
+    ./build.sh -v -i seapath-guest-efi-test-image --distro seapath-guest \
         --machine votp-vm \
         --dl-dir /mnt/dldir \
         --sstate-dir /mnt/sstate && \
-    ./build.sh -v -i seapath-host-efi-test-image \
+    ./build.sh -v -i seapath-host-efi-test-image --distro seapath-host \
         --dl-dir /mnt/dldir \
         --sstate-dir /mnt/sstate && \
     ./build.sh -v \
         -i seapath-monitor-efi-image  \
         --machine votp-monitor \
-        --distro seapath-ro \
+        --distro seapath-host \
         --dl-dir /mnt/dldir \
         --sstate-dir /mnt/sstate \
 '

--- a/README.adoc
+++ b/README.adoc
@@ -216,9 +216,41 @@ created on your machine, it will become persistent. Further calls to `cqfd init`
 will do nothing, unless the container definition (`.cqfd/docker/Dockerfile`) has
 changed in the source tree.
 
-You can then start the build using:
+cqfd provides different flavors that allow to call build.sh with certain image, distro and machine parameters.
+To list the available flavors, run:
 
-  $ cqfd run
+  $ cqfd flavors
+
+Here is a description of flavors:
+
+   * all: all flavors
+   * flash_bios: bios image to flash a server disk
+   * flash_efi: efi image to flash a server disk
+   * flash_pxe: pxe image to flash a server disk
+   * guest_efi: efi guest image (VM) 
+   * guest_efi_test: similar to guest_efi with additionnal test packages
+   * guest_efi_dbg: similar to guest_efi with debug tools
+   * host_bios: bios host image (including security, clustering and readonly features)
+   * host_bios_dbg: similar to host_bios with debug tools
+   * host_bios_minimal: similar to host_bios without security, clustering and readonly features
+   * host_bios_no_iommu: similar to host_bios without IOMMU enabled (IOMMU leads) 
+   * host_bios_test: similar to host_bios with additionnal test packages
+   * host_bios_test_no_iommu: similar to host_bios_no_iommu with additionnal test packages
+   * host_efi: efi host image (including security, clustering and readonly features)
+   * host_efi_dbg: similar to host_efi with debug tools
+   * host_efi_test: similar to host_efi with additionnal test packages
+   * host_efi_swu: efi host update image (SwUpdate)
+   * monitor_bios: bios monitor image (used to monitor the cluster)
+   * monitor_efi: efi monitor image (used to monitor the cluster)
+   * monitor_efi_swu: efi monitor update image (SwUpdate)
+
+To build on of this flavor, run:
+
+  $ cqfd -b <flavor>
+
+Note:
+* bash completion works with `-b` parameter
+* detail command used per flavor is described in `.cqfdrc` file
 
 == Building the firmware manually
 
@@ -239,15 +271,15 @@ The following packages need to be installed:
 
 The build is started by running the following command:
 
-  $ ./build.sh -i seapath-host-efi-image -m boardname
+  $ ./build.sh -i seapath-host-efi-image -m boardname --distro distroname
 
 You can also pass custom BitBake commands using the `--` separator:
 
-  $ ./build.sh -i seapath-host-efi-image -m boardname -- bitbake -c clean package_name
+  $ ./build.sh -i seapath-host-efi-image -m boardname --distro distroname -- bitbake -c clean package_name
 
 Images can be produced for either UEFI or BIOS compatible firmwares.
 
-Yoou can find below the Yocto images list (with [FW]=bios or [FW]=efi):
+You can find below the Yocto images list (with [FW]=bios or [FW]=efi):
 
 * Host images
 ** seapath-host-[FW]-image: production image
@@ -268,6 +300,15 @@ guest with test tool
 during a PXE boot.
 * Observer images
 ** seapath-monitor-[FW]: production image for an observer (needed for clustering quorum establishment)
+
+Different distros can be used:
+
+* seapath-flash: distro used for flash images
+* seapath-guest: distro used for guest images
+* seapath-host: distro used for host images with security, readonly and clustering features 
+* seapath-host-cluster-minimal: distro used for host images with clustering features
+* seapath-host-minimal: distro used for host images without security, readonly and clustering features
+* seapath-host-sb: distro used for host images without security, readonly, clustering and secureboot features
 
 == Building an SDK Installer
 

--- a/build.sh
+++ b/build.sh
@@ -248,7 +248,7 @@ export BB_ENV_EXTRAWHITE="$BB_ENV_EXTRAWHITE \
 # Set image to build, default to core-image-minimal
 export IMAGE=${IMAGE:-"seapath-host-efi-image"}
 export MACHINE=${MACHINE:-"votp"}
-export DISTRO=${DISTRO:-"seapath"}
+export DISTRO=${DISTRO:-"seapath-host"}
 export ACCEPT_FSL_EULA="1"
 
 if [ ! -z "$REMOVE_BUILDDIR" ]; then


### PR DESCRIPTION
SEAPATH features can now be enabled or disabled with Yocto DISTRO_FEATURES.

This Yocto features are:
* **seapath-clustering**: enable the clustering features
* **seapath-security**: enforce security
* **seapath-readonly**: enable the read only rootfs
* **seapath-overlay**: enable overlays partitions to store persistent data on read only rootfs

The SEAPAH Yocto DISTRO is now:
* *seapath-host*: for hypervisors including all SEAPATH features excepted the secure boot
* *seapath-host-sb*: as *seapath-host*: with secure boot support
* *seapath-guest*: for guest including all SEAPATH features
* *seapath-flash*: use by flash images
* *seapath-host-cluster-minimal*: for hypervisors with clustering support
* *seapath-host-minimal*: for hypervisors without any SEAPATH features

The default DISTRO is *seapath-host*.

Add the cqfd flavor: host_bios_minimal.