### PR TITLE
Add SEAPATH customization file

### DIFF
--- a/.cqfdrc
+++ b/.cqfdrc
@@ -44,11 +44,11 @@ command=' \
     ./build.sh -v -i seapath-host-bios-image --distro seapath-host && \
     ./build.sh -v -i seapath-host-bios-dbg-image --distro seapath-host && \
     ./build.sh -v \
-        -i seapath-host-bios-no-iommu-image \
+        -i seapath-host-bios-image \
         --machine votp-no-iommu \
         --distro seapath-host && \
     ./build.sh -v -i seapath-host-bios-test-image --distro seapath-host && \
-    ./build.sh -v -i seapath-host-bios-test-no-iommu-image \
+    ./build.sh -v -i seapath-host-bios-test-image \
         --machine votp-no-iommu --distro seapath-host && \
     ./build.sh -v -i seapath-host-efi-dbg-image --distro seapath-host && \
     ./build.sh -v -i seapath-host-efi-test-image --distro seapath-host && \
@@ -91,7 +91,7 @@ command='./build.sh -v -i seapath-host-bios-image --distro seapath-host-minimal'
 
 [host_bios_no_iommu]
 command='./build.sh -v \
-    -i seapath-host-bios-no-iommu-image \
+    -i seapath-host-bios-image \
     --machine votp-no-iommu \
     --distro seapath-host'
 
@@ -102,7 +102,7 @@ command='./build.sh -v -i seapath-host-bios-dbg-image --distro seapath-host'
 command='./build.sh -v -i seapath-host-bios-test-image --distro seapath-host'
 
 [host_bios_test_no_iommu]
-command='./build.sh -v -i seapath-host-bios-test-no-iommu-image \
+command='./build.sh -v -i seapath-host-bios-test-image \
         --machine votp-no-iommu --distro seapath-host'
 
 [host_efi]

--- a/.cqfdrc
+++ b/.cqfdrc
@@ -35,14 +35,36 @@ flavors='
 
 [all]
 command=' \
-    ./build.sh -v -i seapath-flash-bios --distro seapath-flash && \
-    ./build.sh -v -i seapath-flash-efi --distro seapath-flash && \
-    ./build.sh -v -i seapath-flash-pxe --distro seapath-flash && \
-    ./build.sh -v -i seapath-guest-efi-image --distro seapath-guest --machine votp-vm && \
-    ./build.sh -v -i seapath-guest-efi-test-image --distro seapath-guest --machine votp-vm && \
-    ./build.sh -v -i seapath-guest-efi-dbg-image --distro seapath-guest --machine votp-vm && \
-    ./build.sh -v -i seapath-host-bios-image --distro seapath-host && \
-    ./build.sh -v -i seapath-host-bios-dbg-image --distro seapath-host && \
+    ./build.sh -v \
+        -i seapath-flash-bios \
+        --distro seapath-flash \
+        --machine votp-flash && \
+    ./build.sh -v \
+        -i seapath-flash-efi \
+        --distro seapath-flash \
+        --machine votp-flash && \
+    ./build.sh -v \
+        -i seapath-flash-pxe \
+        --distro seapath-flash \
+        --machine votp-flash && \
+    ./build.sh -v \
+        -i seapath-guest-efi-image \
+        --distro seapath-guest \
+        --machine votp-guest && \
+    ./build.sh -v \
+        -i seapath-guest-efi-test-image \
+        --distro seapath-guest \
+        --machine votp-guest && \
+    ./build.sh -v \
+        -i seapath-guest-efi-dbg-image \
+        --distro seapath-guest \
+        --machine votp-guest && \
+    ./build.sh -v \
+        -i seapath-host-bios-image \
+        --distro seapath-host && \
+    ./build.sh -v \
+        -i seapath-host-bios-dbg-image \
+        --distro seapath-host && \
     ./build.sh -v \
         -i seapath-host-bios-image \
         --machine votp-no-iommu \
@@ -66,22 +88,31 @@ command=' \
 '
 
 [flash_bios]
-command='./build.sh -v -i seapath-flash-bios --distro seapath-flash'
+command='./build.sh -v \
+    -i seapath-flash-bios \
+    --distro seapath-flash \
+    --machine votp-flash'
 
 [flash_efi]
-command='./build.sh -v -i seapath-flash-efi --distro seapath-flash'
+command='./build.sh -v \
+    -i seapath-flash-efi \
+    --distro seapath-flash \
+    --machine votp-flash'
 
 [flash_pxe]
-command='./build.sh -v -i seapath-flash-pxe --distro seapath-flash'
+command='./build.sh -v \
+    -i seapath-flash-pxe \
+    --distro seapath-flash \
+    --machine votp-flash'
 
 [guest_efi]
-command='./build.sh -v -i seapath-guest-efi-image --distro seapath-guest --machine votp-vm'
+command='./build.sh -v -i seapath-guest-efi-image --distro seapath-guest --machine votp-guest'
 
 [guest_efi_dbg]
-command='./build.sh -v -i seapath-guest-efi-dbg-image --distro seapath-guest --machine votp-vm'
+command='./build.sh -v -i seapath-guest-efi-dbg-image --distro seapath-guest --machine votp-guest'
 
 [guest_efi_test]
-command='./build.sh -v -i seapath-guest-efi-test-image --distro seapath-guest --machine votp-vm'
+command='./build.sh -v -i seapath-guest-efi-test-image --distro seapath-guest --machine votp-guest'
 
 [host_bios]
 command='./build.sh -v -i seapath-host-bios-image --distro seapath-host'
@@ -148,14 +179,15 @@ command=' \
         --sstate-dir /mnt/sstate && \
     ./build.sh -v -i seapath-flash-pxe \
         --distro seapath-flash \
+        --machine votp-flash \
         --dl-dir /mnt/dldir \
         --sstate-dir /mnt/sstate && \
     ./build.sh -v -i seapath-guest-efi-image --distro seapath-guest \
-        --machine votp-vm \
+        --machine votp-guest \
         --dl-dir /mnt/dldir \
         --sstate-dir /mnt/sstate && \
     ./build.sh -v -i seapath-guest-efi-test-image --distro seapath-guest \
-        --machine votp-vm \
+        --machine votp-guest \
         --dl-dir /mnt/dldir \
         --sstate-dir /mnt/sstate && \
     ./build.sh -v -i seapath-host-efi-test-image --distro seapath-host \

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ README.pdf
 !keys/README.adoc
 keys/*
 .repo/
+seapath.conf

--- a/build.sh
+++ b/build.sh
@@ -243,6 +243,7 @@ export IMAGE=${IMAGE:-"seapath-host-efi-image"}
 export MACHINE=${MACHINE:-"votp-host"}
 export DISTRO=${DISTRO:-"seapath-host"}
 export ACCEPT_FSL_EULA="1"
+export LSB_WARN='0'
 if [ -f seapath.conf ] ; then
     for seapath_env in $(bash -c \
         '( source seapath.conf ; set -o posix ; set \
@@ -268,6 +269,7 @@ export BB_ENV_EXTRAWHITE="$BB_ENV_EXTRAWHITE \
   MACHINE \
   SSTATE_DIR \
   ACCEPT_FSL_EULA \
+  LSB_WARN \
 "
 if [ ! -z "$REMOVE_BUILDDIR" ]; then
   # Clean directory

--- a/build.sh
+++ b/build.sh
@@ -240,7 +240,7 @@ done
 
 # Set image to build, default to core-image-minimal
 export IMAGE=${IMAGE:-"seapath-host-efi-image"}
-export MACHINE=${MACHINE:-"votp"}
+export MACHINE=${MACHINE:-"votp-host"}
 export DISTRO=${DISTRO:-"seapath-host"}
 export ACCEPT_FSL_EULA="1"
 if [ -f seapath.conf ] ; then

--- a/patches/0010-grub-efi-install-grub.cfg-from-build-directory.patch
+++ b/patches/0010-grub-efi-install-grub.cfg-from-build-directory.patch
@@ -1,0 +1,31 @@
+From 104c19541acf5252cbe818a998aa071fa68e8427 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Mathieu=20Dupr=C3=A9?= <mathieu.dupre@savoirfairelinux.com>
+Date: Thu, 27 Jan 2022 09:54:00 +0100
+Subject: [PATCH] grub-efi: install grub.cfg from build directory
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Install grub.cfg based on grub-efi.cfg from build directory.
+
+Signed-off-by: Mathieu Dupré <mathieu.dupre@savoirfairelinux.com>
+---
+ .../recipes-bsp/grub/grub-efi-efi-secure-boot.inc               | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/meta-efi-secure-boot/recipes-bsp/grub/grub-efi-efi-secure-boot.inc b/meta-efi-secure-boot/recipes-bsp/grub/grub-efi-efi-secure-boot.inc
+index 7b2c414..f3089f4 100644
+--- a/meta-efi-secure-boot/recipes-bsp/grub/grub-efi-efi-secure-boot.inc
++++ b/meta-efi-secure-boot/recipes-bsp/grub/grub-efi-efi-secure-boot.inc
+@@ -116,7 +116,7 @@ do_install_append_class-target() {
+ 
+     # Install the stacked grub configs.
+     install -d "${D}${EFI_BOOT_PATH}"
+-    install -m 0600 "${WORKDIR}/grub-efi.cfg" "${D}${EFI_BOOT_PATH}/grub.cfg"
++    install -m 0600 "${B}/grub-efi.cfg" "${D}${EFI_BOOT_PATH}/grub.cfg"
+     install -d "${D}${EFI_BOOT_PATH}/${GRUB_TARGET}-efi"
+     grub-mkimage -c ../cfg -p "${GRUB_PREFIX_DIR}" -d "./grub-core" \
+         -O "${GRUB_TARGET}-efi" -o "${B}/${GRUB_IMAGE}" \
+-- 
+2.25.1
+

--- a/seapath.conf.sample
+++ b/seapath.conf.sample
@@ -4,3 +4,6 @@
 # SEAPATH configuration file sample
 # This file can be used as example to create a seapath.conf file.
 # Each variable defined here is set as it default value.
+
+# Keymap
+SEAPATH_KEYMAP='us'

--- a/seapath.conf.sample
+++ b/seapath.conf.sample
@@ -24,3 +24,14 @@ SEAPATH_RT_CORES=''
 # If the do not use DPDK do not set this variable.
 # Warning: each 1 GiB hugepage reserved can not be used as system memory.
 SEAPATH_1G_HUGEPAGES=''
+
+
+# Hashed password to access Grub shell if security is enabled.
+# The password has to be stored hashed in pbkdf2 format.
+# To generate the hashed from the plain password, the following command can be
+# used:
+# grub-mkpasswd-pbkdf2 -c 65536 -s 256 -l 64
+SEAPATH_GRUB_PASSWORD=''
+
+# Time in seconds grub waiting before boot SEAPATH.
+SEAPATH_GRUB_TIMEOUT='0'

--- a/seapath.conf.sample
+++ b/seapath.conf.sample
@@ -10,3 +10,17 @@ SEAPATH_KEYMAP='us'
 
 # Limite the number of jobs to compile Ceph to avoid out of memory errors
 SEAPATH_PARALLEL_MAKE='8'
+
+# CPUs reserved for real time applications, containers and VMs.
+# It can be an single CPU or a plage delimited by - (e.g. 2-5). Mulitples CPUs
+# and plages can be defined using , as seperator (e.g 0,2-5,7,10-12).
+# The CPU enumeration begins at 0, so the maximum value is 1 less than the
+# number of CPUs core on the system.
+# If not defined, no CPU will be reserved.
+SEAPATH_RT_CORES=''
+
+# 1 GiB hugepages reserved in hypervisor
+# 1 GiB hugepages are used by DPDK. It must be 1 + maximum VMs using DPDK
+# If the do not use DPDK do not set this variable.
+# Warning: each 1 GiB hugepage reserved can not be used as system memory.
+SEAPATH_1G_HUGEPAGES=''

--- a/seapath.conf.sample
+++ b/seapath.conf.sample
@@ -7,3 +7,6 @@
 
 # Keymap
 SEAPATH_KEYMAP='us'
+
+# Limite the number of jobs to compile Ceph to avoid out of memory errors
+SEAPATH_PARALLEL_MAKE='8'

--- a/seapath.conf.sample
+++ b/seapath.conf.sample
@@ -1,0 +1,6 @@
+# Copyright (C) 2022, RTE (http://www.rte-france.com)
+# SPDX-License-Identifier: Apache-2.0
+
+# SEAPATH configuration file sample
+# This file can be used as example to create a seapath.conf file.
+# Each variable defined here is set as it default value.

--- a/seapath.conf.sample
+++ b/seapath.conf.sample
@@ -35,3 +35,9 @@ SEAPATH_GRUB_PASSWORD=''
 
 # Time in seconds grub waiting before boot SEAPATH.
 SEAPATH_GRUB_TIMEOUT='0'
+
+# Set to true to disable IPv6.
+SEAPATH_DISABLE_IPV6='false'
+
+# Set to true to disable IPv6 for guest images
+SEAPATH_GUEST_DISABLE_IPV6='false'


### PR DESCRIPTION
Modify SEAPATH to support custom variables. Custom variables can be defined in the seapath.conf file, in the environment or in Yocto local.conf file.
    
All SEAPATH custom variables begin with SEAPTH_.

All available variables are described in the seapath.conf.sample file.

These variables are Yocto variables with [Yocto override syntax](https://docs.yoctoproject.org/bitbake/bitbake-user-manual/bitbake-user-manual-metadata.html#conditional-syntax-overrides ) support.

Refactor wic, machine and images:
* remove no-iommu images. Using is enough to generate an image without IOMMU support enabled.
* do not define kernel parameters in WIC files and remove wic files becoming useless
* remove votp-vm to votp-guest for coherency
* create the votp-flash machine
* remove votp machine and create votp-host machine instead
