### PR TITLE
remove .gitreview

### DIFF
--- a/.gitreview
+++ b/.gitreview
@@ -1,5 +1,0 @@
-[gerrit]
-host = g1.sfl.team
-port = 29419
-project = rte/votp/yocto-bsp
-defaultbranch = sfl/master


### PR DESCRIPTION
SEAPATH is host as Github and do not use Gerrit.