### PR TITLE
patches: add patches for npm

### DIFF
--- a/patches/0008-bitbake-fetch2-npmsw-fix-fetching-git-revisions-not-on-master.patch
+++ b/patches/0008-bitbake-fetch2-npmsw-fix-fetching-git-revisions-not-on-master.patch
@@ -1,0 +1,52 @@
+From: Enguerrand de Ribaucourt @ 2024-07-04 16:23 UTC (permalink / raw)
+  To: bitbake-devel; +Cc: tanguy.raufflet, richard.purdie, Enguerrand de Ribaucourt
+
+The NPM package.json documentation[1] states that git URLs may contain
+a commit-ish suffix to specify a specific revision. When running
+`npm install`, this revision will be looked for on any branch of the
+repository.
+
+The bitbake implementation however translates the URL stored in
+package.json into a git URL to be fetch by the bitbake git fetcher. The
+bitbake fetcher git.py, enforces the branch to be master by default. If
+the revision specified in the package.json is not on the master branch,
+the fetch will fail while the package.json is valid.
+
+To fix this, append the ";nobranch=1" suffix to the revision in the git
+URL to be fetched. This will make the bitbake git fetcher ignore the
+branch and respect the behavior of `npm install``.
+
+This can be tested with the following command:
+ $ devtool add --npm-dev https://github.com/seapath/cockpit-cluster-dashboard.git -B version
+Which points to a project which has a package.json with a git URL:
+```json
+  "devDependencies": {
+    "cockpit-repo": "git+https://github.com/cockpit-project/cockpit.git#d34cabacb8e5e1e028c7eea3d6e3b606d862b8ac"
+  }
+```
+In this repo, the specified revision is on the "main" branch, which
+would fail without this fix.
+
+[1] https://docs.npmjs.com/cli/v10/configuring-npm/package-json#git-urls-as-dependencies
+
+Co-authored-by: Tanguy Raufflet <tanguy.raufflet@savoirfairelinux.com>
+Signed-off-by: Tanguy Raufflet <tanguy.raufflet@savoirfairelinux.com>
+Signed-off-by: Enguerrand de Ribaucourt <enguerrand.de-ribaucourt@savoirfairelinux.com>
+---
+ bitbake/lib/bb/fetch2/npmsw.py | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/sources/poky/bitbake/lib/bb/fetch2/npmsw.py b/sources/poky/bitbake/lib/bb/fetch2/npmsw.py
+index ff5f8dc755..018e0ad546 100644
+--- a/sources/poky/bitbake/lib/bb/fetch2/npmsw.py
++++ b/sources/poky/bitbake/lib/bb/fetch2/npmsw.py
+@@ -184,6 +184,7 @@ class NpmShrinkWrap(FetchMethod):
+                 uri = URI("git://" + str(groups["url"]))
+                 uri.params["protocol"] = str(groups["protocol"])
+                 uri.params["rev"] = str(groups["rev"])
++                uri.params["nobranch"] = "1"
+                 uri.params["destsuffix"] = destsuffix
+ 
+                 url = str(uri)
+-- 
+2.34.1

--- a/patches/0009-npm-accept-unspecified-versions-in-package.json.patch
+++ b/patches/0009-npm-accept-unspecified-versions-in-package.json.patch
@@ -1,0 +1,56 @@
+From: Enguerrand de Ribaucourt @ 2024-07-04 16:23 UTC (permalink / raw)
+  To: bitbake-devel; +Cc: tanguy.raufflet, richard.purdie, Enguerrand de Ribaucourt
+
+Our current emulation mandates that the package.json contains a version
+field. Some packages may not provide it when they are not published to
+the registry. The actual `npm pack` would allow such packages, so
+should we.
+
+This patch adds default values to allow building such packages.
+For the shrinkwrap, we can actually use the resolved field which
+contains the exact source, including the revision, to pass integrity
+tests.
+
+This applies for instance to this package which doesn't declare a
+version:
+ - https://github.com/cockpit-project/cockpit/blob/23701a555a5af13f998ee4c7526d27fdb5669d63/package.json#L2
+
+Co-authored-by: Tanguy Raufflet <tanguy.raufflet@savoirfairelinux.com>
+Signed-off-by: Tanguy Raufflet <tanguy.raufflet@savoirfairelinux.com>
+Signed-off-by: Enguerrand de Ribaucourt <enguerrand.de-ribaucourt@savoirfairelinux.com>
+---
+ bitbake/lib/bb/fetch2/npmsw.py  | 2 +-
+ meta/classes-recipe/npm.bbclass | 4 +++-
+ 2 files changed, 4 insertions(+), 2 deletions(-)
+
+diff --git a/sources/poky/bitbake/lib/bb/fetch2/npmsw.py b/sources/poky/bitbake/lib/bb/fetch2/npmsw.py
+index 018e0ad546..044f5b96f8 100644
+--- a/sources/poky/bitbake/lib/bb/fetch2/npmsw.py
++++ b/sources/poky/bitbake/lib/bb/fetch2/npmsw.py
+@@ -88,7 +88,7 @@ class NpmShrinkWrap(FetchMethod):
+ 
+             integrity = params.get("integrity", None)
+             resolved = params.get("resolved", None)
+-            version = params.get("version", None)
++            version = params.get("version", params.get("resolved", None))
+ 
+             # Handle registry sources
+             if is_semver(version) and integrity:
+diff --git a/sources/poky/meta/classes/npm.bbclass b/sources/poky/meta/classes/npm.bbclass
+index 91da3295f2..a73ff29be8 100644
+--- a/sources/poky/meta/classes/npm.bbclass
++++ b/sources/poky/meta/classes/npm.bbclass
+@@ -75,8 +75,10 @@ def npm_pack(env, srcdir, workdir):
+         j = json.load(f)
+ 
+     # base does not really matter and is for documentation purposes
+-    # only.  But the 'version' part must exist because other parts of
++    # only. But the 'version' part must exist because other parts of
+     # the bbclass rely on it.
++    if 'version' not in j:
++        j['version'] = '0.0.0-unknown'
+     base = j['name'].split('/')[-1]
+     tarball = os.path.join(workdir, "%s-%s.tgz" % (base, j['version']));
+ 
+-- 
+2.34.1


### PR DESCRIPTION
Fix 2 behaviors in npm implementation in Bitbake:
- For a given git URL and a commit-ish in package.json, the fetcher was only looking for the branch named "master".
- The version value was mandatory for all dependencies in the package.json, whereas npm allows this value to be omitted.