### PR TITLE
cqfd: fix monitor_efi_swu machine name

### DIFF
--- a/.cqfdrc
+++ b/.cqfdrc
@@ -157,7 +157,7 @@ command='./build.sh -v \
 [monitor_efi_swu]
 command='./build.sh -v \
     -i seapath-monitor-efi-swu-image \
-    --machine seapath-observer \
+    --machine seapath-monitor \
     --distro seapath-observer \
 '
 


### PR DESCRIPTION
The machine name for the monitor_efi_swu build was incorrect. It was using the seapath-observer machine name instead of the seapath-monitor machine name.