### PR TITLE
.cqfdrc: remove build directory between builds for sfl_ci

### DIFF
--- a/.cqfdrc
+++ b/.cqfdrc
@@ -170,17 +170,17 @@ command='./build.sh -v \
 
 [sfl_ci]
 command=' \
-    ./build.sh -v -i seapath-host-efi-image --distro seapath-host && \
-    ./build.sh -v -i seapath-flasher \
+    ./build.sh -v -r -i seapath-host-efi-image --distro seapath-host && \
+    ./build.sh -v -r -i seapath-flasher \
         --distro seapath-flash \
         --machine seapath-installer && \
-    ./build.sh -v -i seapath-guest-efi-image --distro seapath-guest \
+    ./build.sh -v -r -i seapath-guest-efi-image --distro seapath-guest \
         --machine seapath-vm && \
-    ./build.sh -v \
+    ./build.sh -v -r \
         -i seapath-monitor-efi-image  \
         --machine seapath-monitor \
         --distro seapath-observer && \
-    ./build.sh -v \
+    ./build.sh -v -r \
         -i seapath-observer-rpi-image  \
         --machine seapath-observer-rpi \
         --distro seapath-observer \


### PR DESCRIPTION
The sfl_ci flavor builds multiple images with different distro which can create conflicts in the workdir.

Also, some recipes can fail during build if part of the cache is invalidated and a workdir is already existing.
For example, the libvirt recipe fails with a pseudo error during do_install if a workdir was created with a previous build and do_install should rerun. This is because the do_install task of libvirt triggers a "setup.py install" command for a cython module which also triggers the build command. However, building is not supposed to happen in do_install and conflict with previous pseudo setup.

To prevent such errors, remove the build directory between each image build.