### PR TITLE
Update README.adoc with dependencies

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -167,7 +167,7 @@ The following packages need to be installed:
 
   $ sudo apt-get install -y gawk wget git-core diffstat unzip texinfo gcc-multilib \
      build-essential chrpath socat cpio python python3 python3-pip python3-pexpect \
-     xz-utils debianutils iputils-ping libsdl1.2-dev xterm repo
+     xz-utils debianutils iputils-ping libsdl1.2-dev xterm repo libgmp-dev libmpc-dev
 
 === Building the firmware
 


### PR DESCRIPTION
while building host-efi-image, missing include files gmp.h mpc.h
these 2 libraries will help fixing those missing files error