### PR TITLE
seapath.conf: add SEAPATH_COCKPIT variable

### DIFF
--- a/seapath.conf.sample
+++ b/seapath.conf.sample
@@ -42,3 +42,6 @@ SEAPATH_SECCOMPILE_MANIFEST_SKIP='1'
 # Disk to autoflash with the flasher image. If not set or empty the autoflash
 # will be disabled. Ex : /dev/sda
 SEAPATH_AUTO_FLASH=""
+
+# Set to true to enable the Cockpit web UI interface. Disabled by default.
+SEAPATH_COCKPIT='false'


### PR DESCRIPTION
This variable is used to enable or disable the Cockpit Web UI interface. The interface is disabled by default.