### PR TITLE
ci: hardened permissions and fixed periodic cve check

### DIFF
--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -20,6 +20,14 @@ on:
 jobs:
   build:
     runs-on: ["self-hosted", "runner-sfl-seapath"]
+    # This job may check out potentially unsafe user code from Pull Requests.
+    # Giving it only the necessary permissions mitigates potential token misuse
+    # introduced in user code.
+    # The only step using the GitHub API is the "upload artifacts" one, which
+    # seems to only need the "contents: read" permission as per [1]
+    # [1] https://github.com/actions/upload-artifact/issues/197#issuecomment-3154708082
+    permissions:
+      contents: read
     strategy:
       fail-fast: true # TODO eventually set to false
       max-parallel: 1

--- a/.github/workflows/periodic-cve-check.yml
+++ b/.github/workflows/periodic-cve-check.yml
@@ -21,7 +21,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           run_id=$(curl --silent --get \
-            --url "https://api.github.com/repos/SkytAsul/SEAPATH-yocto-bsp/actions/workflows/push.yml/runs" \
+            --url "https://api.github.com/repos/${{ github.repository }}/actions/workflows/push.yml/runs" \
             --data "per_page=1" \
             --data "status=success" \
             --header "Authorization: Bearer $GH_TOKEN" | \

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -34,6 +34,8 @@ on:
 
 run-name: "PR #${{ inputs.origin_pr_number || github.event.pull_request.number }} at ${{ inputs.origin_repository || github.repository }}"
 
+permissions: read-all
+
 jobs:
   notice:
     name: Display notice

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -30,6 +30,8 @@ on:
 
 run-name: "Push to ${{ inputs.origin_repository || github.repository }}"
 
+permissions: read-all
+
 jobs:
   notice:
     name: Display notice


### PR DESCRIPTION
Workflows now only have a read-enabled token by default.
The build job is even more restricted since it can potentially run malicious user code: it now has the bare minimum permissions to actually run.

Also fixed the periodic cve check workflow by removing a hardcoded variable.