### PR TITLE
cqfd: use new Docker env syntax.

### DIFF
--- a/.cqfd/docker/Dockerfile
+++ b/.cqfd/docker/Dockerfile
@@ -4,11 +4,10 @@
 
 FROM ubuntu:22.04
 
-ENV DEBIAN_FRONTEND noninteractive
-
-ENV LANG en_US.UTF-8
-ENV LANGUAGE en_US.UTF-8
-ENV LC_ALL en_US.UTF-8
+ENV DEBIAN_FRONTEND=noninteractive \
+    LANG=en_US.UTF-8 \
+    LANGUAGE=en_US.UTF-8 \
+    LC_ALL=en_US.UTF-8
 
 # Yocto mandatory packages
 RUN apt-get update && apt-get install -y --no-install-recommends \


### PR DESCRIPTION
It remove the legacy warning about the old syntax.