### PR TITLE
ci: fix PRs from forked repository

### DIFF
--- a/.github/pr-comment.md.j2
+++ b/.github/pr-comment.md.j2
@@ -1,0 +1,25 @@
+{% set workflow_url = "%s/%s/actions/runs/%s" % (github_server_url, pr_repository, pr_run_id) %}
+
+### Build
+{% if build_result == 'success' %}
+**SUCCESS**: all flavors compiled correctly.
+{% else %}
+**FAILED**: build went wrong
+{% endif %}
+
+### CVE Check
+{% if cve_detected == 'true' %}
+**CVE DETECTED**: some vulnerabilities triggered the fail condition.\
+See details in the [workflow run logs]({{ workflow_url }}).
+{% elif cve_detected == 'false' %}
+**CLEAR**: no vulnerabilities have triggered the fail condition.\
+Get information on all vulnerabilities and detected packages in the artifacts of the [workflow run]({{ workflow_url }}).
+{% elif cve_check_result == 'skipped' %}
+**SKIPPED**
+{% else %}
+**FAILED**: CVE detection went wrong
+{% endif %}
+
+---
+> [!NOTE]
+> This is an automated CI report. See the [associated workflow run]({{ workflow_url }})

--- a/.github/workflows/_cve-check.yml
+++ b/.github/workflows/_cve-check.yml
@@ -99,7 +99,7 @@ jobs:
       - name: Run VulnScout
         id: vulnscout
         env:
-          VULNSCOUT_VERSION: latest
+          VULNSCOUT_VERSION: v0.11.1
           VULNSCOUT_CACHE: ${{ env.CACHE_DIR }}/vulnscout
         run: |
           mkdir -p ${{ env.VULNSCOUT_CACHE }}

--- a/.github/workflows/periodic-cve-check.yml
+++ b/.github/workflows/periodic-cve-check.yml
@@ -47,6 +47,7 @@ jobs:
     steps:
       - name: Fail job if CVE detected
         if: "${{ needs.call-cve-check.outputs.cve-detected == 'true' }}"
-        run: |
-          echo ::error::Vulnerabilities triggered the fail condition for the SBOM of the latest build job.
-          exit 1
+        uses: actions/github-script@v8
+        with:
+          script: |
+            core.setFailed("Vulnerabilities triggered the fail condition for the SBOM of the latest build job.")

--- a/.github/workflows/pr-summary.yml
+++ b/.github/workflows/pr-summary.yml
@@ -1,0 +1,79 @@
+name: Pull Requests Summary
+
+# Since we need access to secrets in order to post the summary in pull request
+# comments, we cannot do it in the "pull requests" workflow because when
+# running from a forked repository the secrets are not accessible.
+# Thus we use this separate workflow that automatically runs at the end of the
+# PR workflow to post the comment. This workflow can access secrets.
+on:
+  workflow_run:
+    workflows:
+      - Pull Requests
+    types:
+      - completed
+
+permissions: read-all
+
+jobs:
+  create-summary:
+    name: Create summary
+    # We cannot use ubuntu-slim here since we need Docker for the Jinja2 action
+    # cf. https://github.com/actions/runner-images/issues/13583
+    runs-on: ["ubuntu-latest"]
+    env:
+      PR_RESULTS_FILE: "pr_results.json"
+      PR_COMMENT_FILE: "comment.md"
+      PR_COMMENT_TEMPLATE: ".github/pr-comment.md.j2"
+    steps:
+      - name: Download PR results
+        uses: actions/download-artifact@v8
+        with:
+          name: "${{ env.PR_RESULTS_FILE }}"
+          run-id: "${{ github.event.workflow_run.id }}"
+          # Since we are downloading an artifact from another run, we have to
+          # specify the github-token parameter.
+          github-token: ${{ github.token }}
+
+      - name: Process PR results
+        id: pr-results
+        run: |
+          echo "pr_repository=$(cat "${{ env.PR_RESULTS_FILE }}" | jq -r '.pr_repository')" >> "$GITHUB_OUTPUT"
+          echo "pr_number=$(cat "${{ env.PR_RESULTS_FILE }}" | jq -r '.pr_number')" >> "$GITHUB_OUTPUT"
+          # We don't need to export the rest of the variables since the whole
+          # JSON file is passed to the Jinja2 action as a variable source.
+
+      - name: Checkout comment template
+        uses: actions/checkout@v6
+        with:
+          sparse-checkout: |
+            ${{ env.PR_COMMENT_TEMPLATE }}
+          sparse-checkout-cone-mode: false
+          path: comment
+
+      - name: Generate PR comment
+        uses: cuchi/jinja2-action@8bd801365a8d36a0b20f45ee969161685de7785a
+        with:
+          template: "comment/${{ env.PR_COMMENT_TEMPLATE }}"
+          output_file: "${{ env.PR_COMMENT_FILE }}"
+          data_file: "${{ env.PR_RESULTS_FILE }}"
+          strict: true
+          variables: |
+            github_server_url=${{ github.server_url }}
+            pr_run_id=${{ github.event.workflow_run.id }}
+
+      - name: Create a token
+        id: app-token
+        uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859
+        with:
+          app-id: ${{ vars.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          permission-pull-requests: write
+
+      - name: Write a comment on the PR
+        uses: peter-evans/create-or-update-comment@9143c495e69aa6ad64fa02b7515ccab6bd35aad1
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+          repository: ${{ steps.pr-results.outputs.pr_repository }}
+          issue-number: ${{ steps.pr-results.outputs.pr_number }}
+          body-path: ${{ env.PR_COMMENT_FILE }}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -63,40 +63,38 @@ jobs:
     with:
       build-run-id: ${{ github.run_id }}
 
-  set-result:
+  process-results:
     if: always()
-    name: Set workflow status
+    name: Process results
     needs:
       - call-build
       - call-cve-check
     runs-on: ["ubuntu-slim"]
+    env:
+      PR_RESULTS_FILE: pr_results.json
     steps:
-      - name: Create a token
-        id: app-token
-        uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859
+      - name: Create results file
+        run: |
+          cat <<EOF > ${{ env.PR_RESULTS_FILE }}
+          {
+            "pr_number": ${{ inputs.origin_pr_number || github.event.pull_request.number }},
+            "pr_repository": "${{ inputs.origin_repository || github.repository }}",
+            "build_result": "${{ needs.call-build.result }}",
+            "cve_check_result": "${{ needs.call-cve-check.result }}",
+            "cve_detected": "${{ needs.call-cve-check.outputs.cve-detected }}"
+          }
+          EOF
+
+      - name: Upload results artifact
+        uses: actions/upload-artifact@v7
         with:
-          app-id: ${{ vars.APP_ID }}
-          private-key: ${{ secrets.APP_PRIVATE_KEY }}
-          owner: ${{ github.repository_owner }}
-          permission-pull-requests: write
-
-      - name: Write comment
-        uses: peter-evans/create-or-update-comment@9143c495e69aa6ad64fa02b7515ccab6bd35aad1
-        with:
-          token: ${{ steps.app-token.outputs.token }}
-          repository: ${{ inputs.origin_repository || github.repository }}
-          issue-number: ${{ inputs.origin_pr_number || github.event.pull_request.number }}
-          body: |
-            _Automated CI report ([associated workflow run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}))_
-
-            ### Build
-            ${{ case(needs.call-build.result == 'success', '**SUCCESS**', '**FAILED**' ) }}
-
-            ### CVE Check
-            ${{ case(needs.call-cve-check.outputs.cve-detected == 'false', '**SUCCESS**: no vulnerabilities have triggered the fail condition', '**FAILURE**: some vulnerabilities triggered the fail condition') }}
+          archive: false
+          path: "${{ env.PR_RESULTS_FILE }}"
+          retention-days: 1
 
       - name: Fail job if CVE detected
         if: "${{ needs.call-cve-check.outputs.cve-detected == 'true' }}"
-        run: |
-          echo ::error::Vulnerabilities triggered the fail condition for your build.
-          exit 1
+        uses: actions/github-script@v8
+        with:
+          script: |
+            core.setFailed("Vulnerabilities triggered the fail condition for your build.")

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -8,6 +8,8 @@ on:
       - opened
       - synchronize
       - reopened
+    paths-ignore:
+      - .github/**/*
 
   # See dispatch explanation in push.yml.
   workflow_dispatch:


### PR DESCRIPTION
When PRs originate from a forked repository, the pull_request workflows do not have access to write-enabled tokens and secrets. However we need them to be able to post the summaries to the PRs.
This PR works around this issue by using a separate workflow_run trigger that do not withdraw the secrets from the context. The code that generates the comment has also been revamped to use a Jinja2 template.

Other unrelated changes:
- froze the VulnScout version to 0.11.1 (so the CI won't break on the next VS update)
- made the PR workflow not run when a PR only contains changes to the CI (to save processing power)